### PR TITLE
Redirect DOI to preferred resolver

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@
     - Jeff Kriske <jekriske@gmail.com>
     - Josef Hrabal <josef.hrabal@vsb.cz>
     - Justin Riley <justin_riley@harvard.edu>
+    - Katrin Leinweber <katrin.leinweber@uni-konstanz.de>
     - Maciej Sieczka <msieczka@sieczka.org>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Nathan Lin <nathan.lin@yale.edu>

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ We also have a Zenodo citation:
 Kurtzer, Gregory M.. (2016). Singularity 2.1.2 - Linux application and environment
 containers for science. 10.5281/zenodo.60736
 
-http://dx.doi.org/10.5281/zenodo.60736
+https://doi.org/10.5281/zenodo.60736
 ```
 
 # Webpage

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-singularity-container (2.5.1-1) unstable; urgency=high
+singularity-container (2.5.1-1) bionic; urgency=medium
 
   [ Yaroslav Halchenko ]
   * debian/control
@@ -8,7 +8,7 @@ singularity-container (2.5.1-1) unstable; urgency=high
   * New upstream bug-fix release
   * Refresh patches
 
- -- Afif Elghraoui <afif@debian.org>  Thu, 03 May 2018 22:12:31 -0400
+ -- KERN packaging <packaging@kernsuite.info>  Thu, 17 May 2018 10:24:26 +0200
 
 singularity-container (2.5.0-1) unstable; urgency=high
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well.

~~**This fixes or addresses the following GitHub issues:**~~

- ~~Ref:~~


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- ~~I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.~~ _no, because only a link update_
- ~~I have tested this PR locally with a `make test`~~ _no, because only a link update_
- ~~This PR is NOT against the project's master branch~~ _The `base:` selector above offered me only `master`_
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
